### PR TITLE
Fix background theme wrapper

### DIFF
--- a/projects/wirvsvirus-staatlichekommunikation/src/app/app/app.component.scss
+++ b/projects/wirvsvirus-staatlichekommunikation/src/app/app/app.component.scss
@@ -1,8 +1,12 @@
 @import '../../styles-variables';
 
 .theme-wrapper {
-  height: 100%;
-  width: 100%;
+  display: flex;
+  min-height: 100vh;
+}
+
+.mat-drawer-container {
+  flex: 1;
 }
 
 .mat-sidenav-container {
@@ -80,11 +84,9 @@
   }
 
   .wrapper {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
+    margin: 0 auto;
+    height: 100%;
+    width: 100%;
     display: flex;
     flex-direction: column;
 
@@ -172,10 +174,10 @@
     }
   }
   @media (min-width: map-get($grid-breakpoints, md)) {
-  .branding img {
-    filter: brightness(0) invert(1);
+    .branding img {
+      filter: brightness(0) invert(1);
+    }
   }
-}
   @media (max-width: map-get($grid-breakpoints, md)) {
     .toolbar {
       bottom: 0;

--- a/projects/wirvsvirus-staatlichekommunikation/src/index.html
+++ b/projects/wirvsvirus-staatlichekommunikation/src/index.html
@@ -14,9 +14,6 @@
 
   <link rel="icon" type="image/png" href="./assets/coronavorort-logo-1-blau.png">
   <style type="text/css">
-    body, html {
-      height: 100%;
-    }
     .app-loading {
       position: relative;
       display: flex;


### PR DESCRIPTION
In order to display the theme correctly the flex sizing was ajusted.

For small content the background was 100% but when the content overflows the wrapper, the background color was not filling the whole background plane. This behavior could be seen best when choosing the 'dark' theme and switching between `/weiteres` and `/about/glossar` (white area at the bottom of the page) routes.

These changes fix this issue, but have not been tested entirely. Feel free to contact me with questions.